### PR TITLE
Fix typos in embed builders.

### DIFF
--- a/examples/basic_chatbot.rs
+++ b/examples/basic_chatbot.rs
@@ -18,7 +18,7 @@ fn main() {
 			Ok(Event::MessageCreate(message)) => {
 				println!("{} says: {}", message.author.name, message.content);
 				if message.content == "!test" {
-					let _ = discord.send_message(&message.channel_id, "This is a reply to the test.", "", false);
+					let _ = discord.send_message(message.channel_id, "This is a reply to the test.", "", false);
 				} else if message.content == "!quit" {
 					println!("Quitting.");
 					break

--- a/examples/dj.rs
+++ b/examples/dj.rs
@@ -78,7 +78,7 @@ pub fn main() {
 							"You must be in a voice channel to DJ".to_owned()
 						};
 						if !output.is_empty() {
-							warn(discord.send_message(&message.channel_id, &output, "", false));
+							warn(discord.send_message(message.channel_id, &output, "", false));
 						}
 					}
 				}

--- a/examples/logbot.rs
+++ b/examples/logbot.rs
@@ -38,7 +38,7 @@ fn main() {
 		// Log messages
 		match event {
 			Event::MessageCreate(message) => {
-				match state.find_channel(&message.channel_id) {
+				match state.find_channel(message.channel_id) {
 					Some(ChannelRef::Public(server, channel)) => {
 						println!("[{} #{}] {}: {}", server.name, channel.name, message.author.name, message.content);
 					}

--- a/examples/login_cache.rs
+++ b/examples/login_cache.rs
@@ -3,6 +3,7 @@ extern crate discord;
 use discord::Discord;
 use std::env;
 
+#[allow(deprecated)]
 fn main() {
 	// To see the token cache in action, try the following sequence of commands:
 	// $ cargo run --example login_cache <email>

--- a/examples/voice_receive.rs
+++ b/examples/voice_receive.rs
@@ -13,7 +13,7 @@ use discord::model::{Event, UserId};
 struct VoiceTest;
 
 impl AudioReceiver for VoiceTest {
-	fn speaking_update(&mut self, ssrc: u32, user_id: &UserId, speaking: bool) {
+	fn speaking_update(&mut self, ssrc: u32, user_id: UserId, speaking: bool) {
 		println!("[{}] is {:?} -> {}", ssrc, user_id, speaking);
 	}
 
@@ -79,7 +79,7 @@ pub fn main() {
 							voice.connect(channel_id);
 							voice.set_receiver(Box::new(VoiceTest));
 						} else {
-							warn(discord.send_message(&message.channel_id, "You must be in a voice channel.", "", false));
+							warn(discord.send_message(message.channel_id, "You must be in a voice channel.", "", false));
 						}
 					}
 				}

--- a/src/builders.rs
+++ b/src/builders.rs
@@ -3,7 +3,6 @@
 //! These types do not usually need to be imported, but the methods available
 //! on them are very relevant to where they are used.
 
-use serde_json;
 use serde_json::builder::{ObjectBuilder, ArrayBuilder};
 use model::*;
 
@@ -36,6 +35,9 @@ builder! {
 	/// Patch content for the `edit_profile` call.
 	EditProfile(ObjectBuilder);
 
+	/// Patch content for the `edit_user_profile` call.
+	EditUserProfile(ObjectBuilder);
+
 	/// Patch content for the `send_embed` call.
 	EmbedBuilder(ObjectBuilder);
 
@@ -62,18 +64,12 @@ impl EditServer {
 
 	/// Edit the server's icon. Use `None` to remove the icon.
 	pub fn icon(self, icon: Option<&str>) -> Self {
-		EditServer(match icon {
-			Some(icon) => self.0.insert("icon", icon),
-			None => self.0.insert("icon", serde_json::Value::Null),
-		})
+		EditServer(self.0.insert("icon", icon))
 	}
 
 	/// Edit the server's AFK channel. Use `None` to select no AFK channel.
 	pub fn afk_channel(self, channel: Option<ChannelId>) -> Self {
-		EditServer(match channel {
-			Some(ch) => self.0.insert("afk_channel_id", ch.0),
-			None => self.0.insert("afk_channel_id", serde_json::Value::Null),
-		})
+		EditServer(self.0.insert("afk_channel_id", channel.map(|c| c.0)))
 	}
 
 	/// Edit the server's AFK timeout.
@@ -93,10 +89,7 @@ impl EditServer {
 
 	/// Edit the server's splash. Use `None` to remove the splash.
 	pub fn splash(self, splash: Option<&str>) -> Self {
-		EditServer(match splash {
-			Some(splash) => self.0.insert("splash", splash),
-			None => self.0.insert("splash", serde_json::Value::Null),
-		})
+		EditServer(self.0.insert("splash", splash))
 	}
 }
 
@@ -163,26 +156,35 @@ impl EditProfile {
 
 	/// Edit the user's avatar. Use `None` to remove the avatar.
 	pub fn avatar(self, icon: Option<&str>) -> Self {
-		EditProfile(match icon {
-			Some(icon) => self.0.insert("avatar", icon),
-			None => self.0.insert("avatar", serde_json::Value::Null),
-		})
+		EditProfile(self.0.insert("avatar", icon))
 	}
+}
 
-	/// Provide the user's current password for authentication. Does not apply to bot accounts, and
-	/// must be supplied for user accounts.
+impl EditUserProfile {
+	/// Provide the user's current password for authentication. Required if
+	/// the email or password is being changed.
 	pub fn password(self, password: &str) -> Self {
-		EditProfile(self.0.insert("password", password))
+		EditUserProfile(self.0.insert("password", password))
 	}
 
-	/// Edit the user's email address. Does not apply to bot accounts.
+	/// Edit the user's email address.
 	pub fn email(self, email: &str) -> Self {
-		EditProfile(self.0.insert("email", email))
+		EditUserProfile(self.0.insert("email", email))
 	}
 
-	/// Edit the user's password. Does not apply to bot accounts.
+	/// Edit the user's password.
 	pub fn new_password(self, password: &str) -> Self {
-		EditProfile(self.0.insert("new_password", password))
+		EditUserProfile(self.0.insert("new_password", password))
+	}
+
+	/// Edit the user's username. Must be between 2 and 32 characters long.
+	pub fn username(self, username: &str) -> Self {
+		EditUserProfile(self.0.insert("username", username))
+	}
+
+	/// Edit the user's avatar. Use `None` to remove the avatar.
+	pub fn avatar(self, icon: Option<&str>) -> Self {
+		EditUserProfile(self.0.insert("avatar", icon))
 	}
 }
 

--- a/src/builders.rs
+++ b/src/builders.rs
@@ -219,14 +219,14 @@ impl EmbedBuilder {
 		EmbedBuilder(self.0.insert("footer", f(EmbedFooterBuilder(ObjectBuilder::new())).0.build()))
 	}
 
-	/// Add "image information". See the `EmbedImageBuilder` struct for the editable fields.
+	/// Add "source url of image". Only supports http(s).
 	pub fn image(self, url: &str) -> Self {
 		EmbedBuilder(self.0.insert("image", ObjectBuilder::new().insert("url", url).build()))
 	}
 
-	/// Add "thumbnail information". See the `EmbedThumbnailBuilder` struct for the editable fields.
+	/// Add "source url of thumbnail". Only supports http(s).
 	pub fn thumbnail(self, url: &str) -> Self {
-		EmbedBuilder(self.0.insert("image", ObjectBuilder::new().insert("url", url).build()))
+		EmbedBuilder(self.0.insert("thumbnail", ObjectBuilder::new().insert("url", url).build()))
 	}
 
 	/// Add "author information". See the `EmbedAuthorBuilder` struct for the editable fields.

--- a/src/builders.rs
+++ b/src/builders.rs
@@ -1,0 +1,277 @@
+//! Builder types used for patches and other complex data structures.
+//!
+//! These types do not usually need to be imported, but the methods available
+//! on them are very relevant to where they are used.
+
+use serde_json;
+use serde_json::builder::{ObjectBuilder, ArrayBuilder};
+use model::*;
+
+macro_rules! builder {
+	($(#[$attr:meta] $name:ident($inner:ty);)*) => {
+		$(
+			#[$attr]
+			pub struct $name($inner);
+
+			impl $name {
+				#[doc(hidden)]
+				pub fn __build<F: FnOnce($name) -> $name>(f: F, inp: $inner) -> $inner {
+					f($name(inp)).0
+				}
+			}
+		)*
+	}
+}
+
+builder! {
+	/// Patch content for the `edit_server` call.
+	EditServer(ObjectBuilder);
+
+	/// Patch content for the `edit_channel` call.
+	EditChannel(ObjectBuilder);
+
+	/// Patch content for the `edit_member` call.
+	EditMember(ObjectBuilder);
+
+	/// Patch content for the `edit_profile` call.
+	EditProfile(ObjectBuilder);
+
+	/// Patch content for the `send_embed` call.
+	EmbedBuilder(ObjectBuilder);
+
+	/// Inner patch content for the `send_embed` call.
+	EmbedFooterBuilder(ObjectBuilder);
+
+	/// Inner patch content for the `send_embed` call.
+	EmbedAuthorBuilder(ObjectBuilder);
+
+	/// Inner patch content for the `send_embed` call.
+	EmbedFieldsBuilder(ArrayBuilder);
+}
+
+impl EditServer {
+	/// Edit the server's name.
+	pub fn name(self, name: &str) -> Self {
+		EditServer(self.0.insert("name", name))
+	}
+
+	/// Edit the server's voice region.
+	pub fn region(self, region: &str) -> Self {
+		EditServer(self.0.insert("region", region))
+	}
+
+	/// Edit the server's icon. Use `None` to remove the icon.
+	pub fn icon(self, icon: Option<&str>) -> Self {
+		EditServer(match icon {
+			Some(icon) => self.0.insert("icon", icon),
+			None => self.0.insert("icon", serde_json::Value::Null),
+		})
+	}
+
+	/// Edit the server's AFK channel. Use `None` to select no AFK channel.
+	pub fn afk_channel(self, channel: Option<ChannelId>) -> Self {
+		EditServer(match channel {
+			Some(ch) => self.0.insert("afk_channel_id", ch.0),
+			None => self.0.insert("afk_channel_id", serde_json::Value::Null),
+		})
+	}
+
+	/// Edit the server's AFK timeout.
+	pub fn afk_timeout(self, timeout: u64) -> Self {
+		EditServer(self.0.insert("afk_timeout", timeout))
+	}
+
+	/// Transfer ownership of the server to a new owner.
+	pub fn owner(self, owner: UserId) -> Self {
+		EditServer(self.0.insert("owner_id", owner.0))
+	}
+
+	/// Edit the verification level of the server.
+	pub fn verification_level(self, verification_level: VerificationLevel) -> Self {
+		EditServer(self.0.insert("verification_level", verification_level.num()))
+	}
+
+	/// Edit the server's splash. Use `None` to remove the splash.
+	pub fn splash(self, splash: Option<&str>) -> Self {
+		EditServer(match splash {
+			Some(splash) => self.0.insert("splash", splash),
+			None => self.0.insert("splash", serde_json::Value::Null),
+		})
+	}
+}
+
+impl EditChannel {
+	/// Edit the channel's name.
+	pub fn name(self, name: &str) -> Self {
+		EditChannel(self.0.insert("name", name))
+	}
+
+	/// Edit the text channel's topic.
+	pub fn topic(self, topic: &str) -> Self {
+		EditChannel(self.0.insert("topic", topic))
+	}
+
+	/// Edit the channel's position in the list.
+	pub fn position(self, position: u64) -> Self {
+		EditChannel(self.0.insert("position", position))
+	}
+
+	/// Edit the voice channel's bitrate.
+	pub fn bitrate(self, bitrate: u64) -> Self {
+		EditChannel(self.0.insert("bitrate", bitrate))
+	}
+
+	/// Edit the voice channel's user limit. Both `None` and `Some(0)` mean "unlimited".
+	pub fn user_limit(self, user_limit: u64) -> Self {
+		EditChannel(self.0.insert("user_limit", user_limit))
+	}
+}
+
+impl EditMember {
+	/// Edit the member's nickname. Supply the empty string to remove a nickname.
+	pub fn nickname(self, nick: &str) -> Self {
+		EditMember(self.0.insert("nick", nick))
+	}
+
+	/// Edit whether the member is server-muted.
+	pub fn mute(self, mute: bool) -> Self {
+		EditMember(self.0.insert("mute", mute))
+	}
+
+	/// Edit whether the member is server-deafened.
+	pub fn deaf(self, deafen: bool) -> Self {
+		EditMember(self.0.insert("deaf", deafen))
+	}
+
+	/// Edit the member's assigned roles.
+	pub fn roles(self, roles: &[RoleId]) -> Self {
+		EditMember(self.0.insert_array("roles",
+			|ab| roles.iter().fold(ab, |ab, id| ab.push(id.0))))
+	}
+
+	/// Move the member to another voice channel.
+	pub fn channel(self, channel: ChannelId) -> Self {
+		EditMember(self.0.insert("channel_id", channel.0))
+	}
+}
+
+impl EditProfile {
+	/// Edit the user's username. Must be between 2 and 32 characters long.
+	pub fn username(self, username: &str) -> Self {
+		EditProfile(self.0.insert("username", username))
+	}
+
+	/// Edit the user's avatar. Use `None` to remove the avatar.
+	pub fn avatar(self, icon: Option<&str>) -> Self {
+		EditProfile(match icon {
+			Some(icon) => self.0.insert("avatar", icon),
+			None => self.0.insert("avatar", serde_json::Value::Null),
+		})
+	}
+
+	/// Provide the user's current password for authentication. Does not apply to bot accounts, and
+	/// must be supplied for user accounts.
+	pub fn password(self, password: &str) -> Self {
+		EditProfile(self.0.insert("password", password))
+	}
+
+	/// Edit the user's email address. Does not apply to bot accounts.
+	pub fn email(self, email: &str) -> Self {
+		EditProfile(self.0.insert("email", email))
+	}
+
+	/// Edit the user's password. Does not apply to bot accounts.
+	pub fn new_password(self, password: &str) -> Self {
+		EditProfile(self.0.insert("new_password", password))
+	}
+}
+
+impl EmbedBuilder {
+	/// Add the "title of embed".
+	pub fn title(self, title: &str) -> Self {
+		EmbedBuilder(self.0.insert("title", title))
+	}
+
+	/// Add the "description of embed".
+	pub fn description(self, description: &str) -> Self {
+		EmbedBuilder(self.0.insert("description", description))
+	}
+
+	/// Add the "url of embed".
+	pub fn url(self, url: &str) -> Self {
+		EmbedBuilder(self.0.insert("url", url))
+	}
+
+	/// Add the "timestamp of embed content".
+	pub fn timestamp(self, timestamp: &str) -> Self {
+		EmbedBuilder(self.0.insert("timestamp", timestamp))
+	}
+
+	/// Add the "color code of the embed".
+	pub fn color(self, color: u64) -> Self {
+		EmbedBuilder(self.0.insert("color", color))
+	}
+
+	/// Add "footer information". See the `EmbedFooterBuilder` struct for the editable fields.
+	pub fn footer<F: FnOnce(EmbedFooterBuilder) -> EmbedFooterBuilder>(self, f: F) -> Self {
+		EmbedBuilder(self.0.insert("footer", f(EmbedFooterBuilder(ObjectBuilder::new())).0.build()))
+	}
+
+	/// Add "image information". See the `EmbedImageBuilder` struct for the editable fields.
+	pub fn image(self, url: &str) -> Self {
+		EmbedBuilder(self.0.insert("image", ObjectBuilder::new().insert("url", url).build()))
+	}
+
+	/// Add "thumbnail information". See the `EmbedThumbnailBuilder` struct for the editable fields.
+	pub fn thumbnail(self, url: &str) -> Self {
+		EmbedBuilder(self.0.insert("image", ObjectBuilder::new().insert("url", url).build()))
+	}
+
+	/// Add "author information". See the `EmbedAuthorBuilder` struct for the editable fields.
+	pub fn author<F: FnOnce(EmbedAuthorBuilder) -> EmbedAuthorBuilder>(self, f: F) -> Self {
+		EmbedBuilder(self.0.insert("author", f(EmbedAuthorBuilder(ObjectBuilder::new())).0.build()))
+	}
+
+	/// Add "fields information". See the `EmbedFieldsBuilder` struct for the editable fields.
+	pub fn fields<F: FnOnce(EmbedFieldsBuilder) -> EmbedFieldsBuilder>(self, f: F) -> Self {
+		EmbedBuilder(self.0.insert("fields", f(EmbedFieldsBuilder(ArrayBuilder::new())).0.build()))
+	}
+}
+
+impl EmbedFooterBuilder {
+	/// Add the "footer text".
+	pub fn text(self, text: &str) -> Self {
+		EmbedFooterBuilder(self.0.insert("text", text))
+	}
+
+	/// Add the "url of footer icon". Only the http(s) protocols are supported.
+	pub fn icon_url(self, icon_url: &str) -> Self {
+		EmbedFooterBuilder(self.0.insert("icon_url", icon_url))
+	}
+}
+
+impl EmbedAuthorBuilder {
+	/// Add the "name of author".
+	pub fn name(self, name: &str) -> Self {
+		EmbedAuthorBuilder(self.0.insert("name", name))
+	}
+
+	/// Add the "url of author".
+	pub fn url(self, url: &str) -> Self {
+		EmbedAuthorBuilder(self.0.insert("url", url))
+	}
+
+	/// Add the "url of author icon". Only the http(s) protocols are supported.
+	pub fn icon_url(self, icon_url: &str) -> Self {
+		EmbedAuthorBuilder(self.0.insert("icon_url", icon_url))
+	}
+}
+
+impl EmbedFieldsBuilder {
+	/// Add an entire field structure, representing a mapping from `name` to `value`.
+	///
+	/// `inline` determines "whether or not this field should display inline".
+	pub fn field(self, name: &str, value: &str, inline: bool) -> Self {
+		EmbedFieldsBuilder(self.0.push(ObjectBuilder::new().insert("name", name).insert("value", value).insert("inline", inline).build()))
+	}
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,11 +211,21 @@ impl Discord {
 	}
 
 	/// Log in as a bot account using the given authentication token.
+	/// The token will automatically be prefixed with "Bot ".
 	pub fn from_bot_token(token: &str) -> Result<Discord> {
 		Ok(Discord {
 			rate_limits: RateLimits::default(),
 			client: hyper::Client::new(),
 			token: format!("Bot {}", token.trim()),
+		})
+	}
+
+	/// Log in as a user account using the given authentication token.
+	pub fn from_user_token(token: &str) -> Result<Discord> {
+		Ok(Discord {
+			rate_limits: RateLimits::default(),
+			client: hyper::Client::new(),
+			token: token.trim().to_owned(),
 		})
 	}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@ extern crate base64;
 extern crate flate2;
 
 use std::collections::BTreeMap;
-use serde_json::builder::{ObjectBuilder, ArrayBuilder};
+use serde_json::builder::ObjectBuilder;
 
 mod ratelimit;
 mod error;
@@ -55,11 +55,13 @@ macro_rules! cdn_concat {
 }
 
 pub mod model;
+pub mod builders;
 
 pub use error::{Result, Error};
 pub use connection::Connection;
 pub use state::{State, ChannelRef};
 use model::*;
+use builders::*;
 use ratelimit::RateLimits;
 
 const USER_AGENT: &'static str = concat!("DiscordBot (https://github.com/SpaceManiac/discord-rs, ", env!("CARGO_PKG_VERSION"), ")");
@@ -313,7 +315,7 @@ impl Discord {
 			},
 			Channel::Group(group) => ObjectBuilder::new().insert("name", group.name),
 		};
-		let map = f(EditChannel(map)).0.build();
+		let map = EditChannel::__build(f, map).build();
 		let body = try!(serde_json::to_string(&map));
 		let response = request!(self, patch(body), "/channels/{}", channel);
 		PublicChannel::decode(try!(serde_json::from_reader(response)))
@@ -449,7 +451,10 @@ impl Discord {
 	/// See the `EmbedBuilder` struct for the editable fields.
 	/// `text` may be empty.
 	pub fn send_embed<F: FnOnce(EmbedBuilder) -> EmbedBuilder>(&self, channel: ChannelId, text: &str, f: F) -> Result<Message> {
-		let map = ObjectBuilder::new().insert("content", text).insert("embed", f(EmbedBuilder(ObjectBuilder::new())).0.build()).build();
+		let map = ObjectBuilder::new()
+			.insert("content", text)
+			.insert("embed", EmbedBuilder::__build(f, Default::default()).build())
+			.build();
 		let body = try!(serde_json::to_string(&map));
 		let response = request!(self, post(body), "/channels/{}/messages", channel);
 		Message::decode(try!(serde_json::from_reader(response)))
@@ -698,7 +703,7 @@ impl Discord {
 	/// );
 	/// ```
 	pub fn edit_server<F: FnOnce(EditServer) -> EditServer>(&self, server_id: ServerId, f: F) -> Result<Server> {
-		let map = f(EditServer(ObjectBuilder::new())).0.build();
+		let map = EditServer::__build(f, Default::default()).build();
 		let body = try!(serde_json::to_string(&map));
 		let response = request!(self, patch(body), "/guilds/{}", server_id);
 		Server::decode(try!(serde_json::from_reader(response)))
@@ -841,7 +846,7 @@ impl Discord {
 	///
 	/// See the `EditMember` struct for the editable fields.
 	pub fn edit_member<F: FnOnce(EditMember) -> EditMember>(&self, server: ServerId, user: UserId, f: F) -> Result<()> {
-		let map = f(EditMember(ObjectBuilder::new())).0.build();
+		let map = EditMember::__build(f, Default::default()).build();
 		let body = try!(serde_json::to_string(&map));
 		check_empty(request!(self, patch(body), "/guilds/{}/members/{}", server, user))
 	}
@@ -897,7 +902,7 @@ impl Discord {
 		}
 
 		// Then, send the profile patch.
-		let map = f(EditProfile(map)).0.build();
+		let map = EditProfile::__build(f, map).build();
 		let body = try!(serde_json::to_string(&map));
 		let response = request!(self, patch(body), "/users/@me");
 		let mut json: BTreeMap<String, serde_json::Value> = try!(serde_json::from_reader(response));
@@ -1086,193 +1091,6 @@ pub enum GetMessages {
 	After(MessageId),
 	/// Get N/2 messages before, N/2 messages after, and the specified message.
 	Around(MessageId),
-}
-
-/// Patch content for the `edit_server` call.
-pub struct EditServer(ObjectBuilder);
-
-impl EditServer {
-	/// Edit the server's name.
-	pub fn name(self, name: &str) -> Self {
-		EditServer(self.0.insert("name", name))
-	}
-	/// Edit the server's voice region.
-	pub fn region(self, region: &str) -> Self {
-		EditServer(self.0.insert("region", region))
-	}
-	/// Edit the server's icon. Use `None` to remove the icon.
-	pub fn icon(self, icon: Option<&str>) -> Self {
-		EditServer(match icon {
-			Some(icon) => self.0.insert("icon", icon),
-			None => self.0.insert("icon", serde_json::Value::Null),
-		})
-	}
-	/// Edit the server's AFK channel. Use `None` to select no AFK channel.
-	pub fn afk_channel(self, channel: Option<ChannelId>) -> Self {
-		EditServer(match channel {
-			Some(ch) => self.0.insert("afk_channel_id", ch.0),
-			None => self.0.insert("afk_channel_id", serde_json::Value::Null),
-		})
-	}
-	/// Edit the server's AFK timeout.
-	pub fn afk_timeout(self, timeout: u64) -> Self {
-		EditServer(self.0.insert("afk_timeout", timeout))
-	}
-
-	/// Transfer ownership of the server to a new owner.
-	pub fn owner(self, owner: UserId) -> Self {
-		EditServer(self.0.insert("owner_id", owner.0))
-	}
-
-	/// Edit the verification level of the server.
-	pub fn verification_level(self, verification_level: VerificationLevel) -> Self {
-		EditServer(self.0.insert("verification_level", verification_level.num()))
-	}
-
-	/// Edit the server's splash. Use `None` to remove the splash.
-	pub fn splash(self, splash: Option<&str>) -> Self {
-		EditServer(match splash {
-			Some(splash) => self.0.insert("splash", splash),
-			None => self.0.insert("splash", serde_json::Value::Null),
-		})
-	}
-}
-
-/// Patch content for the `edit_channel` call.
-pub struct EditChannel(ObjectBuilder);
-
-impl EditChannel {
-	/// Edit the channel's name.
-	pub fn name(self, name: &str) -> Self {
-		EditChannel(self.0.insert("name", name))
-	}
-	/// Edit the text channel's topic.
-	pub fn topic(self, topic: &str) -> Self {
-		EditChannel(self.0.insert("topic", topic))
-	}
-	/// Edit the channel's position in the list.
-	pub fn position(self, position: u64) -> Self {
-		EditChannel(self.0.insert("position", position))
-	}
-	/// Edit the voice channel's bitrate.
-	pub fn bitrate(self, bitrate: u64) -> Self {
-		EditChannel(self.0.insert("bitrate", bitrate))
-	}
-	/// Edit the voice channel's user limit. Both `None` and `Some(0)` mean "unlimited".
-	pub fn user_limit(self, user_limit: u64) -> Self {
-		EditChannel(self.0.insert("user_limit", user_limit))
-	}
-}
-
-/// Patch content for the `edit_member` call.
-pub struct EditMember(ObjectBuilder);
-
-impl EditMember {
-	/// Edit the member's nickname. Supply the empty string to remove a nickname.
-	pub fn nickname(self, nick: &str) -> Self {
-		EditMember(self.0.insert("nick", nick))
-	}
-	/// Edit whether the member is server-muted.
-	pub fn mute(self, mute: bool) -> Self {
-		EditMember(self.0.insert("mute", mute))
-	}
-	/// Edit whether the member is server-deafened.
-	pub fn deaf(self, deafen: bool) -> Self {
-		EditMember(self.0.insert("deaf", deafen))
-	}
-	/// Edit the member's assigned roles.
-	pub fn roles(self, roles: &[RoleId]) -> Self {
-		EditMember(self.0.insert_array("roles",
-			|ab| roles.iter().fold(ab, |ab, id| ab.push(id.0))))
-	}
-	/// Move the member to another voice channel.
-	pub fn channel(self, channel: ChannelId) -> Self {
-		EditMember(self.0.insert("channel_id", channel.0))
-	}
-}
-
-/// Patch content for the `edit_profile` call.
-pub struct EditProfile(ObjectBuilder);
-
-impl EditProfile {
-	/// Edit the user's username. Must be between 2 and 32 characters long.
-	pub fn username(self, username: &str) -> Self {
-		EditProfile(self.0.insert("username", username))
-	}
-	/// Edit the user's avatar. Use `None` to remove the avatar.
-	pub fn avatar(self, icon: Option<&str>) -> Self {
-		EditProfile(match icon {
-			Some(icon) => self.0.insert("avatar", icon),
-			None => self.0.insert("avatar", serde_json::Value::Null),
-		})
-	}
-	/// Provide the user's current password for authentication. Does not apply to bot accounts, and
-	/// must be supplied for user accounts.
-	pub fn password(self, password: &str) -> Self {
-		EditProfile(self.0.insert("password", password))
-	}
-	/// Edit the user's email address. Does not apply to bot accounts.
-	pub fn email(self, email: &str) -> Self {
-		EditProfile(self.0.insert("email", email))
-	}
-	/// Edit the user's password. Does not apply to bot accounts.
-	pub fn new_password(self, password: &str) -> Self {
-		EditProfile(self.0.insert("new_password", password))
-	}
-}
-
-/// Patch content for the `send_embed` call.
-pub struct EmbedBuilder(ObjectBuilder);
-impl EmbedBuilder {
-	/// Add the "title of embed".
-	pub fn title(self, title: &str) -> Self { EmbedBuilder(self.0.insert("title", title)) }
-	/// Add the "description of embed".
-	pub fn description(self, description: &str) -> Self { EmbedBuilder(self.0.insert("description", description)) }
-	/// Add the "url of embed".
-	pub fn url(self, url: &str) -> Self { EmbedBuilder(self.0.insert("url", url)) }
-	/// Add the "timestamp of embed content".
-	pub fn timestamp(self, timestamp: &str) -> Self { EmbedBuilder(self.0.insert("timestamp", timestamp)) }
-	/// Add the "color code of the embed".
-	pub fn color(self, color: u64) -> Self { EmbedBuilder(self.0.insert("color", color)) }
-	/// Add "footer information". See the `EmbedFooterBuilder` struct for the editable fields.
-	pub fn footer<F: FnOnce(EmbedFooterBuilder) -> EmbedFooterBuilder>(self, f: F) -> Self { EmbedBuilder(self.0.insert("footer", f(EmbedFooterBuilder(ObjectBuilder::new())).0.build())) }
-	/// Add "image information". See the `EmbedImageBuilder` struct for the editable fields.
-	pub fn image(self, url: &str) -> Self { EmbedBuilder(self.0.insert("image", ObjectBuilder::new().insert("url", url).build())) }
-	/// Add "thumbnail information". See the `EmbedThumbnailBuilder` struct for the editable fields.
-	pub fn thumbnail(self, url: &str) -> Self { EmbedBuilder(self.0.insert("image", ObjectBuilder::new().insert("url", url).build())) }
-	/// Add "author information". See the `EmbedAuthorBuilder` struct for the editable fields.
-	pub fn author<F: FnOnce(EmbedAuthorBuilder) -> EmbedAuthorBuilder>(self, f: F) -> Self { EmbedBuilder(self.0.insert("author", f(EmbedAuthorBuilder(ObjectBuilder::new())).0.build())) }
-	/// Add "fields information". See the `EmbedFieldsBuilder` struct for the editable fields.
-	pub fn fields<F: FnOnce(EmbedFieldsBuilder) -> EmbedFieldsBuilder>(self, f: F) -> Self { EmbedBuilder(self.0.insert("fields", f(EmbedFieldsBuilder(ArrayBuilder::new())).0.build())) }
-}
-
-/// Inner patch content for the `send_embed` call.
-pub struct EmbedFooterBuilder(ObjectBuilder);
-impl EmbedFooterBuilder {
-	/// Add the "footer text".
-	pub fn text(self, text: &str) -> Self { EmbedFooterBuilder(self.0.insert("text", text)) }
-	/// Add the "url of footer icon". Only the http(s) protocols are supported.
-	pub fn icon_url(self, icon_url: &str) -> Self { EmbedFooterBuilder(self.0.insert("icon_url", icon_url)) }
-}
-
-/// Inner patch content for the `send_embed` call.
-pub struct EmbedAuthorBuilder(ObjectBuilder);
-impl EmbedAuthorBuilder {
-	/// Add the "name of author".
-	pub fn name(self, name: &str) -> Self { EmbedAuthorBuilder(self.0.insert("name", name)) }
-	/// Add the "url of author".
-	pub fn url(self, url: &str) -> Self { EmbedAuthorBuilder(self.0.insert("url", url)) }
-	/// Add the "url of author icon". Only the http(s) protocols are supported.
-	pub fn icon_url(self, icon_url: &str) -> Self { EmbedAuthorBuilder(self.0.insert("icon_url", icon_url)) }
-}
-
-/// Inner patch content for the `send_embed` call.
-pub struct EmbedFieldsBuilder(ArrayBuilder);
-impl EmbedFieldsBuilder {
-	/// Add an entire field structure, representing a mapping from `name` to `value`.
-	///
-	/// `inline` determines "whether or not this field should display inline".
-	pub fn field(self, name: &str, value: &str, inline: bool) -> Self { EmbedFieldsBuilder(self.0.push(ObjectBuilder::new().insert("name", name).insert("value", value).insert("inline", inline).build())) }
 }
 
 /// Send a request with the correct `UserAgent`, retrying it a second time if the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,6 +103,10 @@ pub struct Discord {
 
 impl Discord {
 	/// Log in to the Discord Rest API and acquire a token.
+	///
+	/// **Deprecated**: login automation is not recommended. Use
+	/// `from_user_token` instead.
+	#[deprecated]
 	pub fn new(email: &str, password: &str) -> Result<Discord> {
 		let mut map = BTreeMap::new();
 		map.insert("email", email);
@@ -131,6 +135,11 @@ impl Discord {
 	/// Cached login tokens are keyed to the email address and will be read from
 	/// and written to the specified path. If no cached token was found and no
 	/// password was specified, an error is returned.
+	///
+	/// **Deprecated**: login automation is not recommended. Use
+	/// `from_user_token` instead.
+	#[deprecated]
+	#[allow(deprecated)]
 	pub fn new_cache<P: AsRef<std::path::Path>>(path: P, email: &str, password: Option<&str>) -> Result<Discord> {
 		use std::io::{Write, BufRead, BufReader};
 		use std::fs::File;
@@ -211,25 +220,21 @@ impl Discord {
 	}
 
 	/// Log in as a bot account using the given authentication token.
+	///
 	/// The token will automatically be prefixed with "Bot ".
 	pub fn from_bot_token(token: &str) -> Result<Discord> {
-		Ok(Discord {
-			rate_limits: RateLimits::default(),
-			client: hyper::Client::new(),
-			token: format!("Bot {}", token.trim()),
-		})
+		Ok(Discord::from_token_raw(format!("Bot {}", token.trim())))
 	}
 
 	/// Log in as a user account using the given authentication token.
 	pub fn from_user_token(token: &str) -> Result<Discord> {
-		Ok(Discord {
-			rate_limits: RateLimits::default(),
-			client: hyper::Client::new(),
-			token: token.trim().to_owned(),
-		})
+		Ok(Discord::from_token_raw(token.trim().to_owned()))
 	}
 
 	/// Log out from the Discord API, invalidating this clients's token.
+	///
+	/// **Deprecated**: accomplishes nothing and may fail for no reason.
+	#[deprecated]
 	pub fn logout(self) -> Result<()> {
 		let map = ObjectBuilder::new()
 			.insert("provider", serde_json::Value::Null)

--- a/src/model.rs
+++ b/src/model.rs
@@ -145,6 +145,20 @@ id! {
 	EmojiId;
 }
 
+impl ServerId {
+	/// Get the `ChannelId` of this server's main text channel.
+	#[inline(always)]
+	pub fn main(self) -> ChannelId {
+		ChannelId(self.0)
+	}
+
+	/// Get the `RoleId` of this server's `@everyone` role.
+	#[inline(always)]
+	pub fn everyone(self) -> RoleId {
+		RoleId(self.0)
+	}
+}
+
 /// A mention targeted at a specific user, channel, or other entity.
 ///
 /// A mention can be constructed by calling `.mention()` on a mentionable item
@@ -1284,7 +1298,7 @@ impl LiveServer {
 			return Permissions::all();
 		}
 		// OR together all the user's roles
-		let everyone = match self.roles.iter().find(|r| r.id.0 == self.id.0) {
+		let everyone = match self.roles.iter().find(|r| r.id == self.id.everyone()) {
 			Some(r) => r,
 			None => {
 				error!("Missing @everyone role in permissions lookup on {} ({})", self.name, self.id);

--- a/src/state.rs
+++ b/src/state.rs
@@ -435,20 +435,20 @@ impl State {
 	pub fn notes(&self) -> Option<&BTreeMap<UserId, String>> { self.notes.as_ref() }
 
 	/// Look up a private or public channel by its ID.
-	pub fn find_channel(&self, id: &ChannelId) -> Option<ChannelRef> {
+	pub fn find_channel(&self, id: ChannelId) -> Option<ChannelRef> {
 		for server in &self.servers {
 			for channel in &server.channels {
-				if channel.id == *id {
+				if channel.id == id {
 					return Some(ChannelRef::Public(server, channel))
 				}
 			}
 		}
 		for channel in &self.private_channels {
-			if channel.id == *id {
+			if channel.id == id {
 				return Some(ChannelRef::Private(channel))
 			}
 		}
-		if let Some(group) = self.groups.get(id) {
+		if let Some(group) = self.groups.get(&id) {
 			return Some(ChannelRef::Group(group))
 		}
 		None

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -66,7 +66,7 @@ pub trait AudioReceiver: Send {
 	/// This method is the only way to know the `ssrc` to `user_id` mapping, but is unreliable and
 	/// only a hint for when users are actually speaking, due both to latency differences and that
 	/// it is possible for a user to leave `speaking` true even when they are not sending audio.
-	fn speaking_update(&mut self, ssrc: u32, user_id: &UserId, speaking: bool);
+	fn speaking_update(&mut self, ssrc: u32, user_id: UserId, speaking: bool);
 
 	/// Called when a voice packet is received.
 	///
@@ -627,7 +627,7 @@ impl InternalConnection {
 			while let Ok(status) = self.receive_chan.try_recv() {
 				match status {
 					RecvStatus::Websocket(VoiceEvent::SpeakingUpdate { user_id, ssrc, speaking }) => {
-						receiver.speaking_update(ssrc, &user_id, speaking);
+						receiver.speaking_update(ssrc, user_id, speaking);
 					},
 					RecvStatus::Websocket(_) => {},
 					RecvStatus::Udp(packet) => {


### PR DESCRIPTION
Comments for EmbedBuilder::image and EmbedBuilder::thumbnail were wrong,
and thumbnail() contained a string literal `"image"` that should have been
`"thumbnail"`. Apologies.